### PR TITLE
Splitting input and output facts, so the caller can more easily debug…

### DIFF
--- a/app/controllers/RestController.scala
+++ b/app/controllers/RestController.scala
@@ -2,51 +2,75 @@ package controllers
 
 import javax.inject.Inject
 
-import controllers.conversion.{Converter, JsonConversionsProvider}
+import controllers.conversion._
+import controllers.conversion.Converter._
 import org.scalarules.engine.{Context, Fact}
-import play.api.libs.json.{JsError, JsObject, JsSuccess}
-import play.api.mvc.{Action, Controller}
+import play.api.libs.json.{JsError, JsObject, JsSuccess, JsValue}
+import play.api.mvc.{Action, Controller, Request}
 import services.{DerivationsService, GlossariesService, JsonConversionMapsService}
 
 // scalastyle:off public.methods.have.type
 
 class RestController @Inject() (derivationsService: DerivationsService, glossariesService: GlossariesService, jsonConversionMapsService: JsonConversionMapsService) extends Controller {
 
-  val jsonConversionMap: JsonConversionsProvider = jsonConversionMapsService.mergedJsonConversionMap
-
   /**
     * Provides a REST endpoint for triggering all derivations in the target project. Any fact definitions available in the target project's glossaries
     * can be provided in the JSON request body like so:
     * {
-    *   "factOfTypeString": "factText",
-    *   "factOfTypeBedrag": 234,
-    *   "factOfTypeBigDecimal": 234,
-    *   "factOfTypePercentage": 234
+    * "factOfTypeString": "factText",
+    * "factOfTypeBedrag": 234,
+    * "factOfTypeBigDecimal": 234,
+    * "factOfTypePercentage": 234
     * }
     *
     * @return A JsonObject containing either:
     *         - A list of JsErrors, containing complete error information concerning failed conversions from json to context (if multiple errors occur, you receive information on all of them)
-    *         - A JsObject containing three JsObjects:
-    *               - "inputFacts", which contains all the fact information submitted by the caller
-    *               - "outputFacts", which contains all the fact information derived by applying the inputFacts to the rules
-    *               - "allFacts", which contains the combined information of "inputFacts" and "outputFacts"
+    *         - A JsObject containing one JsObject: "facts", which contains the combined information of "input" and "results"
     */
   def runAll = Action(parse.json) { request =>
+    run(request, DefaultResponseJsObject)
+  }
+
+  /**
+    * As #runAll except:
+    *
+    * @return A JsonObject containing either:
+    *         - A list of JsErrors, containing complete error information concerning failed conversions from json to context (if multiple errors occur, you receive information on all of them)
+    *         - A JsObject containing two JsObject: "input" and "results", which contains only the information of "results"
+    */
+  def runAllDebug = Action(parse.json) { request =>
+    run(request, DebugResponseJsObject)
+  }
+
+  /**
+    * As #runAll except:
+    *
+    * @return A JsonObject containing either:
+    *         - A list of JsErrors, containing complete error information concerning failed conversions from json to context (if multiple errors occur, you receive information on all of them)
+    *         - A JsObject containing one JsObject: "results", which contains only the information of "results"
+    */
+  def runAllResultsOnly = Action(parse.json) { request =>
+    run(request, ResultsOnlyResponseJsObject)
+  }
+
+
+  val jsonConversionMap: JsonConversionsProvider = jsonConversionMapsService.mergedJsonConversionMap
+
+  private def run(request: Request[JsValue], jsonResponseProvider: ResponseJsObject) = {
     val (initialContextFragments: List[JsSuccess[Context]], conversionErrors: List[JsError]) =
-      Converter.convertToIndividualContext(request.body, glossariesService.mergedGlossaries, jsonConversionMap)
+      convertToIndividualContext(request.body, glossariesService.mergedGlossaries, jsonConversionMap)
 
-    if(conversionErrors != List.empty)
-      BadRequest(JsError.toJson(conversionErrors.reduceLeft(_ ++ _)))
-    else {
-      val initialContext: Context = initialContextFragments.foldLeft(Map.empty[Fact[Any], Any])((acc, jsSuccess) => acc ++ jsSuccess.get)
-      val resultContext: Context = RulesRunner.run(initialContext, derivationsService.derivations)
+    if (conversionErrors != List.empty) BadRequest( processConversionErrors(conversionErrors) )
+    else Ok( processConvertedContext(initialContextFragments, jsonResponseProvider) )
+  }
 
-      Ok(JsObject(
-          Map("inputFacts" -> Converter.contextToJson(initialContext, jsonConversionMap)) ++
-          Map("outputFacts" -> Converter.contextToJson(resultContext -- initialContext.keys, jsonConversionMap)) ++
-          Map("allFacts" -> Converter.contextToJson(resultContext, jsonConversionMap)))
-      )
-    }
+  private def processConversionErrors(conversionErrors: List[JsError]): JsObject = JsError.toJson(conversionErrors.reduceLeft(_ ++ _))
+
+  private def processConvertedContext(initialContextFragments: List[JsSuccess[Context]], jsonResponse: ResponseJsObject): JsObject = {
+    val initialContext: Context = initialContextFragments.foldLeft(Map.empty[Fact[Any], Any])((acc, jsSuccess) => acc ++ jsSuccess.get)
+    val resultContext: Context = RulesRunner.run(initialContext, derivationsService.derivations)
+
+    jsonResponse.toJson(initialContext = initialContext, resultContext = resultContext, jsonConversionMap)
   }
 
 }

--- a/app/controllers/conversion/Converter.scala
+++ b/app/controllers/conversion/Converter.scala
@@ -11,12 +11,12 @@ object Converter {
     * Converts the JSON input to facts using the facts provided in the factMap.
     * Any JsValues that are not JsObject will be added to the Errors.
     * Any facts not in the factMap will also be added to the Errors.
-    * Any facts whose jsvalue is not of a supported conversion type will also added to the Errors.
+    * Any facts whose JsValue is not of a supported conversion type will also added to the Errors.
     * Returns: a tuple containing:
-    *   - a list of JsSuccess containing a context containing a single fact and its value
+    *   - a list of JsSuccess each containing a context with a single fact and its value
     *   - a list of JsError containing all errors
     *
-    * @param inputJsValue
+    * @param inputJsValue of required type JsObject, containing fact information in the corresponding Json format
     * @param factMap A map from a fact's stringname to the corresponding fact.
     * @param jsonConversionMap A map containing a function from Fact[Type] and JsValue to an instance of the correct Type
     * @return (List[JsSuccess], List[JsError])
@@ -33,5 +33,5 @@ object Converter {
     (successes, errors)
   }
 
-  def contextToJson(context: Context, jsonConversionMap: JsonConversionsProvider): JsValue = writes(context, jsonConversionMap)
+  def contextToJson(context: Context, jsonConversionMap: JsonConversionsProvider): JsObject = writes(context, jsonConversionMap)
 }

--- a/app/controllers/conversion/ImplicitConversions.scala
+++ b/app/controllers/conversion/ImplicitConversions.scala
@@ -19,7 +19,7 @@ object ImplicitConversions {
       * @param conversionMap
       * @return a Json Object containing all existing facts and their corresponding values
       */
-    def writes(context: Context, conversionMap: JsonConversionsProvider): JsValue = {
+    def writes(context: Context, conversionMap: JsonConversionsProvider): JsObject = {
       context.map{ case (fact:Fact[Any], factValue: Any) =>
         conversionMap.contextToJsonConversions.get(factValue.getClass) match {
           case function: Some[ConvertBackFunc] => function.get(fact, factValue)

--- a/app/controllers/conversion/JsResponse.scala
+++ b/app/controllers/conversion/JsResponse.scala
@@ -1,0 +1,26 @@
+package controllers.conversion
+
+import controllers.conversion.Converter._
+import org.scalarules.engine._
+import play.api.libs.json.JsObject
+
+trait ResponseJsObject {
+  def toJson(initialContext: Context, resultContext: Context, jsonConversionMap: JsonConversionsProvider): JsObject
+}
+
+object DebugResponseJsObject extends ResponseJsObject {
+  override def toJson(initialContext: Context, resultContext: Context, jsonConversionMap: JsonConversionsProvider): JsObject =
+    JsObject(Map(
+      "inputs" -> Converter.contextToJson(initialContext, jsonConversionMap),
+      "results" -> contextToJson(resultContext -- initialContext.keys, jsonConversionMap)))
+}
+
+object DefaultResponseJsObject extends ResponseJsObject {
+  override def toJson(initialContext: Context, resultContext: Context, jsonConversionMap: JsonConversionsProvider): JsObject =
+    JsObject(Map("facts" -> Converter.contextToJson(resultContext, jsonConversionMap)))
+}
+
+object ResultsOnlyResponseJsObject extends ResponseJsObject {
+  override def toJson(initialContext: Context, resultContext: Context, jsonConversionMap: JsonConversionsProvider): JsObject =
+    JsObject(Map("results" -> Converter.contextToJson(resultContext -- initialContext.keys, jsonConversionMap)))
+}

--- a/conf/routes
+++ b/conf/routes
@@ -1,6 +1,8 @@
 # Routes for REST/JSON calls to run the derivations
 
 POST /api/run/group/all                                                     controllers.RestController.runAll
+POST /api/run/group/all/debug                                               controllers.RestController.runAllDebug
+POST /api/run/group/all/resultsonly                                         controllers.RestController.runAllResultsOnly
 
 # Routes for retrieving glossary/fact information
 


### PR DESCRIPTION
… what he has sent and which results come from the applied rules:

fixes #2 

an OK response now returns a JsObject containing three JsObjects:
 - inputFacts (the result of converting the Json provided by the caller),
 - outputFacts (the new results when the inputFacts are applied to the rules) and
 - allFacts (the combined facts of inputFacts and outputFacts).

 Also contains some scala doc updates and a more honest returntype for the contextToJson Converter (JsObject instead of JsValue)

Example request to service:
url: ${serveraddress}/api/run/group/all
method: POST
body:
`{
	"TotalPaidHealthCost" : 1000,
	"FlatTaxRate" : 5,
	"BaseIncome" : 20000,
	"HealthCostReimbursementCeiling" : 10000,
	"HealthCostReimbursementPercentage" : 4,
	"TotalPrepaidTaxes" : 2000
}`

example response:
200 OK,
body:
`{
  "inputFacts": {
    "HealthCostReimbursementCeiling": 10000,
    "HealthCostReimbursementPercentage": 4,
    "TotalPaidHealthCost": 1000,
    "TotalPrepaidTaxes": 2000,
    "FlatTaxRate": 5,
    "BaseIncome": 20000
  },
  "outputFacts": {
    "DefaultPaidHealthCost": 0,
    "TaxReturnAmount": 1040,
    "DefaultMinimumOwedTaxes": 0,
    "LegallyOwedTaxes": 960,
    "BaseHealthCosts": 1000,
    "ActualHealthCostReimbursement": 40,
    "HealthCostEligibleForReimbursement": 40,
    "BaseIncomeTax": 1000,
    "TaxesReducedByReimbursements": 960
  },
  "allFacts": {
    "DefaultPaidHealthCost": 0,
    "TaxReturnAmount": 1040,
    "HealthCostReimbursementCeiling": 10000,
    "HealthCostReimbursementPercentage": 4,
    "DefaultMinimumOwedTaxes": 0,
    "LegallyOwedTaxes": 960,
    "TotalPaidHealthCost": 1000,
    "BaseHealthCosts": 1000,
    "TotalPrepaidTaxes": 2000,
    "ActualHealthCostReimbursement": 40,
    "FlatTaxRate": 5,
    "HealthCostEligibleForReimbursement": 40,
    "BaseIncomeTax": 1000,
    "BaseIncome": 20000,
    "TaxesReducedByReimbursements": 960
  }
}`
