### PR TITLE
Update internal reference to Scala-Rules to version 0.4.1

### DIFF
--- a/app/controllers/GlossariesController.scala
+++ b/app/controllers/GlossariesController.scala
@@ -2,7 +2,7 @@ package controllers
 
 import javax.inject._
 
-import org.scalarules.engine.Fact
+import org.scalarules.facts.Fact
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
 import play.api.mvc._

--- a/app/controllers/RestController.scala
+++ b/app/controllers/RestController.scala
@@ -3,7 +3,8 @@ package controllers
 import javax.inject.Inject
 
 import controllers.conversion.{Converter, JsonConversionsProvider}
-import org.scalarules.engine.{Context, Fact}
+import org.scalarules.engine.Context
+import org.scalarules.facts.Fact
 import play.api.libs.json.{JsError, JsSuccess}
 import play.api.mvc.{Action, Controller}
 import services.{DerivationsService, GlossariesService, JsonConversionMapsService}

--- a/app/controllers/RulesRunner.scala
+++ b/app/controllers/RulesRunner.scala
@@ -1,5 +1,6 @@
 package controllers
 
+import org.scalarules.derivations.Derivation
 import org.scalarules.engine._
 
 object RulesRunner {

--- a/app/controllers/conversion/Conversion.scala
+++ b/app/controllers/conversion/Conversion.scala
@@ -1,7 +1,7 @@
 package controllers.conversion
 
 import controllers.conversion.ImplicitConversions._
-import org.scalarules.engine.Fact
+import org.scalarules.facts.Fact
 import org.scalarules.finance.nl._
 import play.api.data.validation.ValidationError
 import play.api.libs.json._

--- a/app/controllers/conversion/Converter.scala
+++ b/app/controllers/conversion/Converter.scala
@@ -3,6 +3,7 @@ package controllers.conversion
 import controllers.conversion.ImplicitConversions.contextReads._
 import controllers.conversion.ImplicitConversions.contextWrites._
 import org.scalarules.engine._
+import org.scalarules.facts.Fact
 import play.api.data.validation.ValidationError
 import play.api.libs.json._
 

--- a/app/controllers/conversion/ImplicitConversions.scala
+++ b/app/controllers/conversion/ImplicitConversions.scala
@@ -1,7 +1,7 @@
 package controllers.conversion
 
-import org.scalarules.engine.Fact
 import org.scalarules.engine.Context
+import org.scalarules.facts.Fact
 import org.scalarules.finance.nl._
 import play.api.data.validation.ValidationError
 import play.api.libs.json._

--- a/app/controllers/conversion/package.scala
+++ b/app/controllers/conversion/package.scala
@@ -1,6 +1,6 @@
 package controllers
 
-import org.scalarules.engine.Fact
+import org.scalarules.facts.Fact
 import play.api.libs.json.{JsObject, JsResult, JsValue}
 
 package object conversion {

--- a/app/services/DerivationsService.scala
+++ b/app/services/DerivationsService.scala
@@ -2,8 +2,7 @@ package services
 
 import javax.inject.{Inject, Singleton}
 
-import org.scalarules.dsl.nl.grammar.Berekening
-import org.scalarules.engine.Derivation
+import org.scalarules.derivations.Derivation
 import play.api.Configuration
 
 @Singleton

--- a/app/services/GlossariesService.scala
+++ b/app/services/GlossariesService.scala
@@ -2,7 +2,7 @@ package services
 
 import javax.inject.{Inject, Singleton}
 
-import org.scalarules.engine.Fact
+import org.scalarules.facts.Fact
 import org.scalarules.utils.Glossary
 import play.api.Configuration
 

--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,7 @@ lazy val ruleRest = (project in file("."))
 
 // *** Dependencies ***
 
-lazy val scalaRulesVersion = "0.3.4"
+lazy val scalaRulesVersion = "0.4.1"
 lazy val scalaTestVersion = "3.0.0"
 lazy val jodaTimeVersion = "2.4"
 lazy val jodaConvertVersion = "1.8"


### PR DESCRIPTION
We've noticed a weakness with the current deployment strategy. The service
incorporates a version of Scala-Rules which basically fixes its use to that
specific version. This commit creates a new version using Scala-Rules 0.4.1,
but we still need to create a better way to deal with this potential variable.