### PR TITLE
Fix a type conversion bug and the inclusion of sub-derivations in group `all`

### DIFF
--- a/app/controllers/RestController.scala
+++ b/app/controllers/RestController.scala
@@ -35,7 +35,7 @@ class RestController @Inject() (derivationsService: DerivationsService, glossari
     else {
       val initialContext: Context = initialContextFragments.foldLeft(Map.empty[Fact[Any], Any])((acc, jsSuccess) => acc ++ jsSuccess.get)
 
-      val resultContext: Context = RulesRunner.run(initialContext, derivationsService.derivations)
+      val resultContext: Context = RulesRunner.run(initialContext, derivationsService.topLevelDerivations)
 
       Ok(Converter.contextToJson(resultContext, jsonConversionMap))
     }

--- a/app/services/DerivationsService.scala
+++ b/app/services/DerivationsService.scala
@@ -9,22 +9,16 @@ import play.api.{Configuration, Logger}
 @Singleton
 class DerivationsService @Inject() (configuration: Configuration, jarLoaderService: JarLoaderService) {
 
-  val derivationsWithMeta: List[DerivationHolder[_ <: Berekening]] = jarLoaderService.jars.flatMap(jarEntry => {
-    jarEntry._2.derivations.map( d => new DerivationHolder(d.berekeningen, d.getClass) )
-  }).toList
+  private val elementBerekeningClass = classOf[ElementBerekening[Any, Any]]
 
-  val derivations: List[Derivation] = derivationsWithMeta.flatMap( _.derivations )
+  val topLevelDerivations: List[Derivation] = {
+    val topLevelDerivationsWithMeta = jarLoaderService.jars.flatMap(
+      jarEntry => { jarEntry._2.derivations.filterNot( d => elementBerekeningClass.isAssignableFrom( d.getClass ))}
+    ).toList
 
-  lazy val elementBerekeningClass = classOf[ElementBerekening[Any, Any]]
-  lazy val topLevelDerivations: List[Derivation] = {
-    val topLevelDerivationsWithMeta = derivationsWithMeta.filter( d => !elementBerekeningClass.isAssignableFrom( d.originalClass ) )
+    Logger.info(s"Detected the following top-level derivations: [${topLevelDerivationsWithMeta.map( _.getClass.getName ).mkString(", ")}]")
 
-    Logger.info(s"Detected the following top-level derivations: [${topLevelDerivationsWithMeta.map( _.originalClass.getName ).mkString(", ")}]")
-
-    topLevelDerivationsWithMeta.flatMap( _.derivations )
+    topLevelDerivationsWithMeta.flatMap( _.berekeningen )
   }
 
 }
-
-class DerivationHolder[T <: Berekening](val derivations: List[Derivation], val originalClass: Class[T])
-

--- a/app/services/DerivationsService.scala
+++ b/app/services/DerivationsService.scala
@@ -3,13 +3,28 @@ package services
 import javax.inject.{Inject, Singleton}
 
 import org.scalarules.derivations.Derivation
-import play.api.Configuration
+import org.scalarules.dsl.nl.grammar.{Berekening, ElementBerekening}
+import play.api.{Configuration, Logger}
 
 @Singleton
 class DerivationsService @Inject() (configuration: Configuration, jarLoaderService: JarLoaderService) {
 
-  val derivations: List[Derivation] = jarLoaderService.jars.flatMap(jarEntry => {
-    jarEntry._2.derivations.map( d => d.berekeningen)
-  }).toList.flatten
+  val derivationsWithMeta: List[DerivationHolder[_ <: Berekening]] = jarLoaderService.jars.flatMap(jarEntry => {
+    jarEntry._2.derivations.map( d => new DerivationHolder(d.berekeningen, d.getClass) )
+  }).toList
+
+  val derivations: List[Derivation] = derivationsWithMeta.flatMap( _.derivations )
+
+  lazy val elementBerekeningClass = classOf[ElementBerekening[Any, Any]]
+  lazy val topLevelDerivations: List[Derivation] = {
+    val topLevelDerivationsWithMeta = derivationsWithMeta.filter( d => !elementBerekeningClass.isAssignableFrom( d.originalClass ) )
+
+    Logger.info(s"Detected the following top-level derivations: [${topLevelDerivationsWithMeta.map( _.originalClass.getName ).mkString(", ")}]")
+
+    topLevelDerivationsWithMeta.flatMap( _.derivations )
+  }
 
 }
+
+class DerivationHolder[T <: Berekening](val derivations: List[Derivation], val originalClass: Class[T])
+

--- a/app/services/GlossariesService.scala
+++ b/app/services/GlossariesService.scala
@@ -4,7 +4,7 @@ import javax.inject.{Inject, Singleton}
 
 import org.scalarules.facts.Fact
 import org.scalarules.utils.Glossary
-import play.api.Configuration
+import play.api.{Configuration, Logger}
 
 @Singleton
 class GlossariesService @Inject()(configuration: Configuration, jarLoaderService: JarLoaderService) {
@@ -12,6 +12,8 @@ class GlossariesService @Inject()(configuration: Configuration, jarLoaderService
   val glossaries: Map[String, Glossary] = jarLoaderService.jars.flatMap( jarEntry => {
     jarEntry._2.glossaries.map( g => (g.getClass.getName, g) )
   })
+
+  Logger.info(s"Detected the following Glossaries: [${glossaries.keys.mkString(", ")}]")
 
   val mergedGlossaries : Map[String, Fact[Any]] = glossaries.values.foldLeft(Map.empty[String, Fact[Any]])((acc, glossary) => acc ++ glossary.facts)
 

--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ lazy val commonSettings = Seq(
   organization := "org.scala-rules",
   organizationHomepage := Some(url("https://github.com/scala-rules")),
   homepage := Some(url("https://github.com/scala-rules/rule-rest")),
-  version := "0.0.4-SNAPSHOT",
+  version := "0.0.4",
   scalaVersion := "2.11.8",
   scalacOptions ++= Seq("-deprecation", "-unchecked", "-feature", "-Xlint", "-Xfatal-warnings")
 ) ++ staticAnalysisSettings ++ publishSettings

--- a/build.sbt
+++ b/build.sbt
@@ -62,6 +62,7 @@ lazy val staticAnalysisSettings = {
 }
 
 addCommandAlias("verify", ";compileScalastyle;testScalastyle;coverage;test;coverageReport;coverageAggregate")
+addCommandAlias("release", ";clean;compile;publishLocal;publishSigned")
 
 // *** Publishing ***
 

--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ lazy val commonSettings = Seq(
   organization := "org.scala-rules",
   organizationHomepage := Some(url("https://github.com/scala-rules")),
   homepage := Some(url("https://github.com/scala-rules/rule-rest")),
-  version := "0.0.4",
+  version := "0.0.5-SNAPSHOT",
   scalaVersion := "2.11.8",
   scalacOptions ++= Seq("-deprecation", "-unchecked", "-feature", "-Xlint", "-Xfatal-warnings")
 ) ++ staticAnalysisSettings ++ publishSettings


### PR DESCRIPTION
The set of default conversions is expanded with a conversion for the Boolean types
and they have been expanded with the actual mapping the rule engine uses for the
Fact.valueType. (The rule-engine uses Scala's weakTypeOf.toString, as opposed to
the getClass.getName). Fixes #6.

The DerivationsService had no way to distinguish between top-level derivations and
those used in sub-derivation constructs. The latter should not be included on the
top level, because they may (and have) attempt to satisfy the same outputs. While
this calls for a better way to namespace facts and derivations, for now the service
differentiates between them based on whether they implement ElementBerekening
or not. Fixes #7.