### PR TITLE
Feature/variable endpoints

### DIFF
--- a/app/controllers/RestController.scala
+++ b/app/controllers/RestController.scala
@@ -21,6 +21,17 @@ class RestController @Inject() (businessServicesService: BusinessServicesService
                                 glossariesService: GlossariesService,
                                 jsonConversionMapsService: JsonConversionMapsService) extends Controller {
 
+  val endpoints: String = businessServicesService.businessServiceNames.map{
+    case businessService:String => "/api/run/group/" + businessService
+  } match {
+    case Nil => "No endpoints available: no BusinessServices have been defined!"
+    case list: List[String] => list.reduceLeft((acc, next) => acc + "\n" + next)
+  }
+
+  def businessservices = Action(
+    Ok(endpoints)
+  )
+
   def runBusinessService(name: String) = Action(parse.json) {
     request =>
       findBusinessService(name) match {
@@ -33,12 +44,12 @@ class RestController @Inject() (businessServicesService: BusinessServicesService
     val matchedBusinessServices = businessServicesService.businessServices.collect{ case (naam, service) if naam == name => (naam, service)}
     matchedBusinessServices match {
       case Nil => Failure(
-        new IllegalStateException("No BusinessService matched this name, make sure you have used the proper endpoint definition!" ++ businessServicesService.businessServiceNames.toString)
+        new IllegalArgumentException("No BusinessService matched this name, make sure you have used the proper endpoint definition!" ++ businessServicesService.businessServiceNames.toString)
       )
       case head :: tail => tail match {
         case Nil => Success(head)
         case tail: List[(String, BusinessService)] => Failure(
-          new IllegalStateException("More than one BusinessService matched with this name. Suspected mistake in BusinessService specifications.")
+          new IllegalStateException("More than one BusinessService matched this name. Suspected mistake in BusinessService specifications.")
         )
       }
     }

--- a/app/controllers/conversion/Conversion.scala
+++ b/app/controllers/conversion/Conversion.scala
@@ -4,59 +4,54 @@ import controllers.conversion.ImplicitConversions._
 import org.scalarules.facts.Fact
 import org.scalarules.finance.nl._
 import play.api.data.validation.ValidationError
-import play.api.libs.json._
+import play.api.libs.json.{JsObject, _}
 
 import scala.reflect.runtime.universe._
 
 trait JsonConversionsProvider {
-  def contextToJsonConversions: Map[Class[_], (Fact[Any], Any) => JsObject]
+  private def convertFacts(fact: Fact[Any], factValue: Any): JsObject = JsObject(Map(fact.name -> turnFactsIntoJson(factValue)))
+
+  private def turnFactsIntoJson(factValue: Any): JsValue = //scalastyle:ignore cyclomatic.complexity
+    try { userSpecifiedConversionsToJson(factValue) }
+    catch { case e: Exception => factValue match {
+      case x :: xs => JsArray(for { elem <- (x :: xs)} yield turnFactsIntoJson(elem))
+      case bedrag: Bedrag => Json.toJson(bedrag)
+      case string: String => Json.toJson(string)
+      case bool: Boolean => JsBoolean(bool)
+      case bool: java.lang.Boolean => JsBoolean(bool)
+      case bigDecimal: BigDecimal => Json.toJson(bigDecimal)
+      case percentage: Percentage => Json.toJson(percentage)
+      case other: Any => throw new IllegalStateException(s"No legal conversion found for $other, with type ${other.getClass} " + e.fillInStackTrace())
+    }
+    }
+
+  def contextToJsonConversions(fact: Fact[Any], factValue: Any): JsObject = convertFacts(fact, factValue)
+
+  /**
+    * override this method in your JsonConversionsProvider to add conversions to Json for types you have implemented,
+    * without losing all the predefined conversions (custom-specified takes precendence).
+    * Example:
+    * override def userSpecifiedConversionsToJson(factValue: Any): JsValue = factValue match {
+        case thingOfYourType: YourType => Json.toJson[YourType](thingOfYourType)
+      }
+    * @param factValue
+    * @return
+    */
+  def userSpecifiedConversionsToJson(factValue: Any): JsValue = factValue match {
+    case _ => throw new IllegalStateException("None of the default matches succeeded and no other matches were provided")
+  }
+
   def jsonToFactConversions: Map[String, ConvertToFunc]
 }
 
 object DefaultJsonConversion extends JsonConversionsProvider {
-  override def contextToJsonConversions: Map[Class[_], ConvertBackFunc] = ContextToJsonConversionMap.contextToJsonConversionMap
   override def jsonToFactConversions: Map[String, ConvertToFunc] = JsonToFactConversionMap.jsonToFactConversionMap
-
-  object ContextToJsonConversionMap {
-    val contextToJsonConversionMap: Map[Class[_], ConvertBackFunc] = Map[Class[_], ConvertBackFunc](
-      classOf[String] -> { contextStringToJsObject(_, _) },
-      classOf[Bedrag] -> { contextBedragToJsObject(_, _) },
-      classOf[Percentage] -> { contextPercentageToJsObject(_, _) },
-      classOf[BigDecimal] -> { contextBigDecimalToJsObject(_, _) },
-      classOf[Boolean] -> { contextBooleanToJsObject(_, _) },
-      classOf[java.lang.Boolean] -> { contextBooleanToJsObject(_, _) }
-    )
-
-    private def contextStringToJsObject(fact: Fact[Any], factValue: Any): JsObject = factValue match {
-      case string: String => JsObject(Map(fact.name -> Json.toJson(factValue.toString)))
-      case _ => throw new IllegalArgumentException
-    }
-
-    private def contextBedragToJsObject(fact: Fact[Any], factValue: Any): JsObject = factValue match {
-      case bedrag: Bedrag => JsObject(Map(fact.name -> Json.toJson[Bedrag](bedrag)))
-      case _ => throw new IllegalArgumentException
-    }
-
-    private def contextPercentageToJsObject(fact: Fact[Any], factValue: Any): JsObject = factValue match {
-      case percentage: Percentage => JsObject(Map(fact.name -> Json.toJson[Percentage](percentage)))
-      case _ => throw new IllegalArgumentException
-    }
-
-    private def contextBigDecimalToJsObject(fact: Fact[Any], factValue: Any): JsObject = factValue match {
-      case bigDecimal: BigDecimal => JsObject(Map(fact.name -> Json.toJson[BigDecimal](bigDecimal)))
-      case _ => throw new IllegalArgumentException
-    }
-
-    private def contextBooleanToJsObject(fact: Fact[Any], factValue: Any): JsObject = factValue match {
-      case bool: Boolean => JsObject(Map(fact.name -> JsBoolean(bool)))
-      case bool: java.lang.Boolean => JsObject(Map(fact.name -> JsBoolean(bool)))
-      case _ => throw new IllegalArgumentException
-    }
-
-  }
 
   object JsonToFactConversionMap {
     val jsonToFactConversionMap: Map[String, ConvertToFunc] = Map[String, ConvertToFunc](
+      weakTypeOf[List[List[List[Bedrag]]]].toString.replace("scala.", "") -> { bedragLijstLijstLijstFunct(_, _) },
+      weakTypeOf[List[List[Bedrag]]].toString.replace("scala.", "") -> { bedragLijstLijstFunct(_, _) },
+      weakTypeOf[List[Bedrag]].toString.replace("scala.", "") -> { bedragLijstFunct(_, _) },
       classOf[String].getTypeName -> { stringFunct(_, _) },
       weakTypeOf[String].toString -> { stringFunct(_, _) },
       classOf[Bedrag].getTypeName -> { bedragFunct(_, _) },
@@ -75,6 +70,21 @@ object DefaultJsonConversion extends JsonConversionsProvider {
     private def bigDecimalFunct(fact: Fact[Any], factValue: JsValue): JsResult[BigDecimal] = factValue match {
       case jsNumber: JsNumber => JsSuccess(jsNumber.value)
       case _ => JsError(ValidationError(s"Conversion for BigDecimal fact ${fact.name} failed, corresponding value was not of expected type JsNumber"))
+    }
+
+    private def bedragLijstLijstLijstFunct(fact: Fact[Any], factValue: JsValue): JsResult[List[List[List[Bedrag]]]] = factValue match {
+      case jsNumber: JsArray => Json.fromJson[List[List[List[Bedrag]]]](jsNumber)
+      case _ => JsError(ValidationError(s"Conversion for Bedrag fact ${fact.name} failed, corresponding value was not of expected type JsNumber"))
+    }
+
+    private def bedragLijstLijstFunct(fact: Fact[Any], factValue: JsValue): JsResult[List[List[Bedrag]]] = factValue match {
+      case jsNumber: JsArray => Json.fromJson[List[List[Bedrag]]](jsNumber)
+      case _ => JsError(ValidationError(s"Conversion for Bedrag fact ${fact.name} failed, corresponding value was not of expected type JsNumber"))
+    }
+
+    private def bedragLijstFunct(fact: Fact[Any], factValue: JsValue): JsResult[List[Bedrag]] = factValue match {
+      case jsNumber: JsArray => Json.fromJson[List[Bedrag]](jsNumber)
+      case _ => JsError(ValidationError(s"Conversion for Bedrag fact ${fact.name} failed, corresponding value was not of expected type JsNumber"))
     }
 
     private def bedragFunct(fact: Fact[Any], factValue: JsValue): JsResult[Bedrag] = factValue match {

--- a/app/controllers/conversion/Converter.scala
+++ b/app/controllers/conversion/Converter.scala
@@ -34,5 +34,7 @@ object Converter {
     (successes, errors)
   }
 
-  def contextToJson(context: Context, jsonConversionMap: JsonConversionsProvider): JsObject = writes(context, jsonConversionMap)
+  def contextToJson(context: Context, jsonConversionMap: JsonConversionsProvider): JsObject =
+    if (context.isEmpty) JsObject(Map.empty[String, JsValue])
+    else writes(context, jsonConversionMap)
 }

--- a/app/controllers/conversion/ImplicitConversions.scala
+++ b/app/controllers/conversion/ImplicitConversions.scala
@@ -21,11 +21,7 @@ object ImplicitConversions {
       */
     def writes(context: Context, conversionMap: JsonConversionsProvider): JsObject = {
       context.map{ case (fact:Fact[Any], factValue: Any) =>
-        conversionMap.contextToJsonConversions.get(factValue.getClass) match {
-          case function: Some[ConvertBackFunc] => function.get(fact, factValue)
-          case None => throw new IllegalStateException(s"Unable to find suitable toJson conversion for Fact with name ${fact.name} with " +
-                                                        s"valuetype ${factValue.getClass.getTypeName} in factConversionMap")
-        }
+        conversionMap.contextToJsonConversions(fact, factValue)
       }.reduceLeft(_ ++ _)
     }
   }

--- a/app/controllers/conversion/JsResponse.scala
+++ b/app/controllers/conversion/JsResponse.scala
@@ -2,25 +2,49 @@ package controllers.conversion
 
 import controllers.conversion.Converter._
 import org.scalarules.engine._
+import org.scalarules.facts.Fact
 import play.api.libs.json.JsObject
 
 trait ResponseJsObject {
-  def toJson(initialContext: Context, resultContext: Context, jsonConversionMap: JsonConversionsProvider): JsObject
+  def toJson(initialContext: Context, uitvoerFacts: List[Fact[Any]], resultContext: Context, jsonConversionMap: JsonConversionsProvider): JsObject
 }
 
-object DebugResponseJsObject extends ResponseJsObject {
-  override def toJson(initialContext: Context, resultContext: Context, jsonConversionMap: JsonConversionsProvider): JsObject =
+object InputsAndOutputsResponseJsObject extends ResponseJsObject {
+  override def toJson(initialContext: Context, uitvoerFacts: List[Fact[Any]], resultContext: Context, jsonConversionMap: JsonConversionsProvider): JsObject =
     JsObject(Map(
-      "inputs" -> Converter.contextToJson(initialContext, jsonConversionMap),
+      "inputs" -> contextToJson(initialContext, jsonConversionMap),
+      "results" -> contextToJson(resultContext.filter(factWithValue => uitvoerFacts.contains(factWithValue._1)), jsonConversionMap)))
+}
+
+object CompleteResponseJsObject extends ResponseJsObject {
+  override def toJson(initialContext: Context, uitvoerFacts: List[Fact[Any]], resultContext: Context, jsonConversionMap: JsonConversionsProvider): JsObject = {
+    JsObject(Map(
+      "inputs" -> contextToJson(initialContext, jsonConversionMap),
+      "intermediateSteps" -> contextToJson(resultContext -- initialContext.keys -- resultContext.filter(factWithValue => (uitvoerFacts.contains(factWithValue._1))).keys, jsonConversionMap),
+      "results" -> contextToJson(resultContext.filter(factWithValue => uitvoerFacts.contains(factWithValue._1)), jsonConversionMap)))
+  }
+}
+
+object OutputsOnlyResponseJsObject extends ResponseJsObject {
+  override def toJson(initialContext: Context, uitvoerFacts: List[Fact[Any]], resultContext: Context, jsonConversionMap: JsonConversionsProvider): JsObject =
+    JsObject(Map(
+      "results" -> contextToJson(resultContext.filter(factWithValue => uitvoerFacts.contains(factWithValue._1)), jsonConversionMap)))
+}
+
+object RunAllResponseJsObject extends ResponseJsObject {
+  override def toJson(initialContext: Context, uitvoerFacts: List[Fact[Any]], resultContext: Context, jsonConversionMap: JsonConversionsProvider): JsObject =
+    JsObject(Map("facts" -> contextToJson(resultContext, jsonConversionMap)))
+}
+
+object DebugAllResponseJsObject extends ResponseJsObject {
+  override def toJson(initialContext: Context, uitvoerFacts: List[Fact[Any]], resultContext: Context, jsonConversionMap: JsonConversionsProvider): JsObject =
+    JsObject(Map(
+      "inputs" -> contextToJson(initialContext, jsonConversionMap),
       "results" -> contextToJson(resultContext -- initialContext.keys, jsonConversionMap)))
 }
 
-object DefaultResponseJsObject extends ResponseJsObject {
-  override def toJson(initialContext: Context, resultContext: Context, jsonConversionMap: JsonConversionsProvider): JsObject =
-    JsObject(Map("facts" -> Converter.contextToJson(resultContext, jsonConversionMap)))
+object RunAllResultsOnlyResponseJsObject extends ResponseJsObject {
+  override def toJson(initialContext: Context, uitvoerFacts: List[Fact[Any]], resultContext: Context, jsonConversionMap: JsonConversionsProvider): JsObject =
+    JsObject(Map("results" -> contextToJson(resultContext -- initialContext.keys, jsonConversionMap)))
 }
 
-object ResultsOnlyResponseJsObject extends ResponseJsObject {
-  override def toJson(initialContext: Context, resultContext: Context, jsonConversionMap: JsonConversionsProvider): JsObject =
-    JsObject(Map("results" -> Converter.contextToJson(resultContext -- initialContext.keys, jsonConversionMap)))
-}

--- a/app/services/BusinessServicesService.scala
+++ b/app/services/BusinessServicesService.scala
@@ -1,0 +1,19 @@
+package services
+
+import javax.inject.{Inject, Singleton}
+
+import org.scalarules.service.dsl.BusinessService
+import play.api.Configuration
+
+@Singleton
+class BusinessServicesService @Inject() (configuration: Configuration, jarLoaderService: JarLoaderService) {
+
+  val businessServices: List[(String, BusinessService)] = jarLoaderService.jars.flatMap {
+    case (jarName: String, jarLoadingResults: JarLoadingResults) => {
+      jarLoadingResults.businessServices.map( businessService => (businessService.getClass.getSimpleName, businessService))
+    }
+  }.toList
+
+  val businessServiceNames: List[String] = businessServices.map{ case (name, _) => name }
+
+}

--- a/app/services/DerivationsService.scala
+++ b/app/services/DerivationsService.scala
@@ -3,7 +3,7 @@ package services
 import javax.inject.{Inject, Singleton}
 
 import org.scalarules.derivations.Derivation
-import org.scalarules.dsl.nl.grammar.{Berekening, ElementBerekening}
+import org.scalarules.dsl.nl.grammar.ElementBerekening
 import play.api.{Configuration, Logger}
 
 @Singleton

--- a/app/services/JarLoaderService.scala
+++ b/app/services/JarLoaderService.scala
@@ -6,6 +6,7 @@ import javax.inject.{Inject, Singleton}
 
 import controllers.conversion.JsonConversionsProvider
 import org.scalarules.dsl.nl.grammar.Berekening
+import org.scalarules.service.dsl.BusinessService
 import org.scalarules.utils.Glossary
 import play.api.Configuration
 
@@ -49,12 +50,14 @@ class JarLoaderService @Inject() (configuration: Configuration) {
     val triedGlossaries: List[Try[Glossary]] = scanAndLoadClasses(jarClassEntries, new GlossaryClassLoader, cl, mirror)
     val triedDerivations: List[Try[Berekening]] = scanAndLoadClasses(jarClassEntries, new DerivationClassLoader, cl, mirror)
     val triedJsonConversionsProviders: List[Try[JsonConversionsProvider]] = scanAndLoadClasses(jarClassEntries, new JsonConversionMapClassLoader, cl, mirror)
+    val triedBusinessServices: List[Try[BusinessService]] = scanAndLoadClasses(jarClassEntries, new BusinessServiceClassLoader, cl, mirror)
 
     JarLoadingResults(
       jarName = location,
       glossaries = triedGlossaries.collect { case Success(glossary) => glossary },
       derivations = triedDerivations.collect { case Success(derivation) => derivation },
-      jsonConversionsProviders = triedJsonConversionsProviders.collect { case Success(jsonConversionsProvider) => jsonConversionsProvider }
+      jsonConversionsProviders = triedJsonConversionsProviders.collect { case Success(jsonConversionsProvider) => jsonConversionsProvider },
+      businessServices = triedBusinessServices.collect {case Success(businessService) => businessService }
     )
   })
 
@@ -74,7 +77,7 @@ object JarLoaderService {
   val CLASS_FILE_SUFFIX = ".class"
 }
 
-case class JarLoadingResults(jarName: String, glossaries: List[Glossary], derivations: List[Berekening], jsonConversionsProviders: List[JsonConversionsProvider])
+case class JarLoadingResults(jarName: String, glossaries: List[Glossary], derivations: List[Berekening], jsonConversionsProviders: List[JsonConversionsProvider], businessServices: List[BusinessService])
 
 /**
   * Implementations of this trait are used by the JarLoaderService to identify and load certain classes and objects from
@@ -138,7 +141,7 @@ class GlossaryClassLoader extends SpecializedClassLoader[Glossary] {
   * Processes JAR-entries looking for classes extending Berekening, which we will instantiate.
   */
 class DerivationClassLoader extends SpecializedClassLoader[Berekening] {
-  // Note: since Berekeningen are classes, we should only consider classes NOT ending with a $, because those are objects.
+  // Note: since Berekeningen are classes, we should only consider classes NOT ending with a $, because those should be objects.
   override def precondition(className: String): Boolean = !className.endsWith("$")
 
   override def preprocessClassName(className: String): String = className
@@ -160,7 +163,7 @@ class DerivationClassLoader extends SpecializedClassLoader[Berekening] {
   * Processes JAR-entries looking for objects extending JsonConversionMap.
   */
 class JsonConversionMapClassLoader extends SpecializedClassLoader[JsonConversionsProvider] {
-  // Note: since Glossaries are objects, we should only consider classes ending with a $, as per the Scala compiler's naming convention
+  // Note: since JsonConversionMaps are objects, we should only consider classes ending with a $, as per the Scala compiler's naming convention
   override def precondition(className: String): Boolean = className.endsWith("$")
 
   // Note: the dropRight(1) ensures the $-sign at the end of the name is removed. The Scala mirror will have no clue what to with the $ and simply requires the name of the object.
@@ -172,6 +175,26 @@ class JsonConversionMapClassLoader extends SpecializedClassLoader[JsonConversion
     val modMirror: ModuleMirror = mirror.reflectModule(jsonConversionsProviderModule)
 
     modMirror.instance.asInstanceOf[JsonConversionsProvider]
+  })
+}
+
+class BusinessServiceClassLoader extends SpecializedClassLoader[BusinessService] {
+  // Note: since BusinessServices are classes, we should only consider classes not ending with a $, as per the Scala compiler's naming convention those would be objects
+  override def precondition(className: String): Boolean = !className.endsWith("$")
+
+  override def preprocessClassName(className: String): String = className
+
+  override def load(className: String, mirror: _root_.scala.reflect.runtime.universe.Mirror): Try[BusinessService] = Try({
+
+    val businessServiceClass: ClassSymbol = mirror.staticClass(className)
+
+    val classMirror: ClassMirror = mirror.reflectClass(businessServiceClass)
+
+    val constructor: MethodSymbol = businessServiceClass.primaryConstructor.asMethod
+
+    val constructorMirror: MethodMirror = classMirror.reflectConstructor(constructor)
+
+    constructorMirror().asInstanceOf[BusinessService]
   })
 }
 

--- a/app/services/JarLoaderService.scala
+++ b/app/services/JarLoaderService.scala
@@ -123,7 +123,7 @@ trait SpecializedClassLoader[T] {
   */
 class GlossaryClassLoader extends SpecializedClassLoader[Glossary] {
   // Note: since Glossaries are objects, we should only consider classes ending with a $, as per the Scala compiler's naming convention
-  override def precondition(className: String): Boolean = className.endsWith("$")
+  override def precondition(className: String): Boolean = className.endsWith("$") && className.collect { case ch: Char if ch == '$' => ch }.length == 1
 
   // Note: the dropRight(1) ensures the $-sign at the end of the name is removed. The Scala mirror will have no clue what to with the $ and simply requires the name of the object.
   override def preprocessClassName(className: String): String = className.dropRight(1)
@@ -164,7 +164,7 @@ class DerivationClassLoader extends SpecializedClassLoader[Berekening] {
   */
 class JsonConversionMapClassLoader extends SpecializedClassLoader[JsonConversionsProvider] {
   // Note: since JsonConversionMaps are objects, we should only consider classes ending with a $, as per the Scala compiler's naming convention
-  override def precondition(className: String): Boolean = className.endsWith("$")
+  override def precondition(className: String): Boolean = className.endsWith("$") && className.collect { case ch: Char if ch == '$' => ch }.length == 1
 
   // Note: the dropRight(1) ensures the $-sign at the end of the name is removed. The Scala mirror will have no clue what to with the $ and simply requires the name of the object.
   override def preprocessClassName(className: String): String = className.dropRight(1)

--- a/app/services/JsonConversionMapsService.scala
+++ b/app/services/JsonConversionMapsService.scala
@@ -4,6 +4,7 @@ import javax.inject.{Inject, Singleton}
 
 import controllers.conversion._
 import play.api.Configuration
+import play.api.libs.json.JsValue
 
 @Singleton
 class JsonConversionMapsService @Inject()(configuration: Configuration, jarLoaderService: JarLoaderService) {
@@ -17,9 +18,11 @@ class JsonConversionMapsService @Inject()(configuration: Configuration, jarLoade
       case (_, map: JsonConversionsProvider) => map.jsonToFactConversions
     }
 
-    override def contextToJsonConversions: Map[Class[_], ConvertBackFunc] = DefaultJsonConversion.contextToJsonConversions ++ jsonConversionMaps.flatMap{
-      case (_, map: JsonConversionsProvider) => map.contextToJsonConversions
-    }
+    override def userSpecifiedConversionsToJson(factValue: Any): JsValue =
+      if (jsonConversionMaps.isEmpty) { DefaultJsonConversion.userSpecifiedConversionsToJson(factValue) }
+      else if (jsonConversionMaps.size > 1) throw new IllegalStateException("Only a single instance of JsonConversionsProvider may be provided!")
+      else { jsonConversionMaps.toList.head._2.userSpecifiedConversionsToJson(factValue) }
+
   }
 
 }

--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ lazy val commonSettings = Seq(
   organization := "org.scala-rules",
   organizationHomepage := Some(url("https://github.com/scala-rules")),
   homepage := Some(url("https://github.com/scala-rules/rule-rest")),
-  version := "0.0.5-SNAPSHOT",
+  version := "0.0.6",
   scalaVersion := "2.11.8",
   scalacOptions ++= Seq("-deprecation", "-unchecked", "-feature", "-Xlint", "-Xfatal-warnings")
 ) ++ staticAnalysisSettings ++ publishSettings

--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,7 @@ lazy val ruleRest = (project in file("."))
 
 // *** Dependencies ***
 
-lazy val scalaRulesVersion = "0.5.0"
+lazy val scalaRulesVersion = "0.5.1"
 lazy val scalaTestVersion = "3.0.0"
 lazy val jodaTimeVersion = "2.4"
 lazy val jodaConvertVersion = "1.8"

--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ lazy val commonSettings = Seq(
   organization := "org.scala-rules",
   organizationHomepage := Some(url("https://github.com/scala-rules")),
   homepage := Some(url("https://github.com/scala-rules/rule-rest")),
-  version := "0.0.7-SNAPSHOT",
+  version := "0.0.5-SNAPSHOT",
   scalaVersion := "2.11.8",
   scalacOptions ++= Seq("-deprecation", "-unchecked", "-feature", "-Xlint", "-Xfatal-warnings")
 ) ++ staticAnalysisSettings ++ publishSettings

--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ lazy val commonSettings = Seq(
   organization := "org.scala-rules",
   organizationHomepage := Some(url("https://github.com/scala-rules")),
   homepage := Some(url("https://github.com/scala-rules/rule-rest")),
-  version := "0.0.6",
+  version := "0.0.7-SNAPSHOT",
   scalaVersion := "2.11.8",
   scalacOptions ++= Seq("-deprecation", "-unchecked", "-feature", "-Xlint", "-Xfatal-warnings")
 ) ++ staticAnalysisSettings ++ publishSettings

--- a/conf/routes
+++ b/conf/routes
@@ -3,6 +3,7 @@
 POST /api/run/group/all                                                     controllers.RestController.runAll
 POST /api/run/group/all/debug                                               controllers.RestController.runAllDebug
 POST /api/run/group/all/resultsonly                                         controllers.RestController.runAllResultsOnly
+POST /api/run/group/:name                                                   controllers.RestController.runBusinessService(name)
 
 # Routes for retrieving glossary/fact information
 

--- a/conf/routes
+++ b/conf/routes
@@ -3,6 +3,7 @@
 POST /api/run/group/all                                                     controllers.RestController.runAll
 POST /api/run/group/all/debug                                               controllers.RestController.runAllDebug
 POST /api/run/group/all/resultsonly                                         controllers.RestController.runAllResultsOnly
+POST /api/run/group/businessservices                                        controllers.RestController.businessservices
 POST /api/run/group/:name                                                   controllers.RestController.runBusinessService(name)
 
 # Routes for retrieving glossary/fact information

--- a/conf/routes
+++ b/conf/routes
@@ -1,10 +1,13 @@
 # Routes for REST/JSON calls to run the derivations
 
 POST /api/run/group/all                                                     controllers.RestController.runAll
-POST /api/run/group/all/debug                                               controllers.RestController.runAllDebug
-POST /api/run/group/all/resultsonly                                         controllers.RestController.runAllResultsOnly
+POST /api/run/group/debug/all                                               controllers.RestController.runAllDebug
+POST /api/run/group/resultsonly/all                                         controllers.RestController.runAllResultsOnly
 POST /api/run/group/businessservices                                        controllers.RestController.businessservices
 POST /api/run/group/:name                                                   controllers.RestController.runBusinessService(name)
+POST /api/run/group/debug/:name                                             controllers.RestController.debugBusinessService(name)
+POST /api/run/group/resultsonly/:name                                       controllers.RestController.debugBusinessService(name)
+POST /api/run/group/information/:name                                       controllers.RestController.information(name)
 
 # Routes for retrieving glossary/fact information
 

--- a/conf/routes
+++ b/conf/routes
@@ -6,7 +6,7 @@ POST /api/run/group/resultsonly/all                                         cont
 POST /api/run/group/businessservices                                        controllers.RestController.businessservices
 POST /api/run/group/:name                                                   controllers.RestController.runBusinessService(name)
 POST /api/run/group/debug/:name                                             controllers.RestController.debugBusinessService(name)
-POST /api/run/group/resultsonly/:name                                       controllers.RestController.debugBusinessService(name)
+POST /api/run/group/resultsonly/:name                                       controllers.RestController.runBusinessServiceOutputsOnly(name)
 POST /api/run/group/information/:name                                       controllers.RestController.information(name)
 
 # Routes for retrieving glossary/fact information


### PR DESCRIPTION
Fixes #11  

Adds a bunch of endpoints supporting scala rules BusinessServices including:

- run debug resultsonly for BusinessServices,
- WARNING, API BREAKING CHANGE: changed the run, debug and resultsonly endpoints for "all" to conform to the new endpoints for BusinessServices
- added an information/:BusinessService endpoint which provides detailed information for the named BusinessService
- the businessservices endpoint now provides a map of businessservices, where the key is the endpoint of the service and the value is the endpoint for information on the service

Changed various formatters to account for the presence of specified uitvoer.
Made Converter.contextToJson more robust by adding an "isEmpty" check on the context. An empty context returns an empty JsObject.