### PR TITLE
Adds CORS headers and String conversions for Bedrag/Percentage/Boolean

### DIFF
--- a/app/Filters.scala
+++ b/app/Filters.scala
@@ -1,0 +1,7 @@
+import javax.inject.Inject
+
+import play.api.http.DefaultHttpFilters
+import play.filters.cors.CORSFilter
+
+class Filters @Inject() (corsFilter: CORSFilter)
+  extends DefaultHttpFilters(corsFilter)

--- a/app/controllers/conversion/Conversion.scala
+++ b/app/controllers/conversion/Conversion.scala
@@ -79,16 +79,19 @@ object DefaultJsonConversion extends JsonConversionsProvider {
 
     private def bedragFunct(fact: Fact[Any], factValue: JsValue): JsResult[Bedrag] = factValue match {
       case jsNumber: JsNumber => Json.fromJson[Bedrag](jsNumber)
+      case jsString: JsString => Json.fromJson[Bedrag](jsString)
       case _ => JsError(ValidationError(s"Conversion for Bedrag fact ${fact.name} failed, corresponding value was not of expected type JsNumber"))
     }
 
     private def percentageFunct(fact: Fact[Any], factValue: JsValue): JsResult[Percentage] = factValue match {
       case jsNumber: JsNumber => Json.fromJson[Percentage](jsNumber)
+      case jsString: JsString => Json.fromJson[Percentage](jsString)
       case _ => JsError(ValidationError(s"Conversion for Percentage fact ${fact.name} failed, corresponding value was not of expected type JsNumber"))
     }
 
     private def booleanFunct(fact: Fact[Any], factValue: JsValue): JsResult[Boolean] = factValue match {
       case jsBoolean: JsBoolean => JsSuccess(jsBoolean.value)
+      case jsString: JsString => JsSuccess(jsString.value.toBoolean)
       case _ => JsError(ValidationError(s"Conversion for String fact ${fact.name} failed, corresponding value was not of expected type JsBoolean"))
     }
 

--- a/app/controllers/conversion/ImplicitConversions.scala
+++ b/app/controllers/conversion/ImplicitConversions.scala
@@ -7,6 +7,7 @@ import play.api.data.validation.ValidationError
 import play.api.libs.json._
 
 import scala.annotation.tailrec
+import scala.util.Try
 
 object ImplicitConversions {
 
@@ -59,6 +60,7 @@ object ImplicitConversions {
   implicit object bedragReads extends Reads[Bedrag] {
     def reads(jsValue: JsValue): JsResult[Bedrag] = jsValue match {
       case jsNumber: JsNumber => JsSuccess(jsNumber.value.euro)
+      case jsString: JsString => Try(JsSuccess(jsString.value.euro)).getOrElse(JsError(ValidationError(s"Unable to convert value '${jsString.value}' to Bedrag, is it numeric?")))
       case other: Any => JsError(ValidationError("error.invalid.bedrag", other))
     }
   }
@@ -72,6 +74,7 @@ object ImplicitConversions {
   implicit object percentageReads extends Reads[Percentage] {
     def reads(jsValue: JsValue): JsResult[Percentage] = jsValue match {
       case jsNumber: JsNumber => JsSuccess(jsNumber.value.procent)
+      case jsString: JsString => Try(JsSuccess(jsString.value.procent)).getOrElse(JsError(ValidationError(s"Unable to convert value '${jsString.value}' to Percentage, is it numeric?")))
       case other: Any => JsError(ValidationError("error.invalid.percentage", other))
     }
   }

--- a/build.sbt
+++ b/build.sbt
@@ -40,7 +40,8 @@ lazy val dependencies = Seq(
   "org.joda" % "joda-convert" % jodaConvertVersion,
   "org.scalatest" %% "scalatest" % scalaTestVersion % Test,
   "org.scalacheck" %% "scalacheck" % "1.12.5" % Test,
-  "com.storm-enroute" %% "scalameter" % "0.7" % Test
+  "com.storm-enroute" %% "scalameter" % "0.7" % Test,
+  filters
 )
 
 // *** Static analysis ***

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -18,3 +18,11 @@ jars.load = [
   // Add location to JARs containing Glossaries and Berekeningen, example:
   // "C:/RootOfM2Folder/.m2/repository/org/scala-rules/examples_2.11/1.0.1-SNAPSHOT/examples_2.11-1.0.1-SNAPSHOT.jar"
 ]
+
+# CORS Configuration
+play.filters.cors {
+  pathPrefixes = ["/"]
+  allowedOrigins = null
+  allowedHttpMethods = ["GET", "POST"]
+  allowedHttpHeaders = null
+}


### PR DESCRIPTION
To enable the Rule Viewer to make calls to any service, this service
layer now enables CORS headers by default for GET and POST operations for
all origins. Note that this can still be overridden by altering the
CORS-config in the application.conf file.